### PR TITLE
Updating requirements for new catalogues

### DIFF
--- a/eada/__init__.py
+++ b/eada/__init__.py
@@ -19,7 +19,7 @@ class Doc:
         Return a functions short description
         """
         import pydoc
-        doc = foo.func_doc
+        doc = foo.__doc__
         s = pydoc.splitdoc(doc)[0]
         return s
     short = synopsis

--- a/eada/io/config.py
+++ b/eada/io/config.py
@@ -111,7 +111,7 @@ def read_ini( filename, *sections ):
         from configparser import ConfigParser
     except:
         from ConfigParser import ConfigParser
-    config = ConfigParser()
+    config = ConfigParser(interpolation=None) #for %2F symbols in urls we need to deactivate interpolation
     config.read(filename)
 
     # Just verify the existence of section (on a real cfg file..):

--- a/eada/vo/conesearch.py
+++ b/eada/vo/conesearch.py
@@ -128,7 +128,7 @@ def main(ra,dec,radius,url,columns=[]):
 
     nobjs = len(scsTab)
 
-    tab = scsTab.votable.to_table()
+    tab = scsTab.votable.get_first_table().to_table()
     if tab is None:
         logging.error("Retrieved table is Null. Exiting")
         return None

--- a/scripts/conesearch
+++ b/scripts/conesearch
@@ -125,7 +125,7 @@ def parseArguments(args,cp):
                 dcat = cp.get(cat)
                 if 'columns' in dcat:
                     cols = dcat.get('columns')
-                    cols = string.split(cols,',')
+                    cols = str.split(cols,',') #not string.split anymore
                 else:
                     cols = []
         else:
@@ -254,7 +254,7 @@ if __name__ == '__main__':
         sys.exit(EXIT_EMPTY)
 
     outfile = args.outfile
-    if args.outfile is '':
+    if args.outfile == '':
         logging.warning("An empty name for output filename was given.")
         outfile = str(ra)+'_'+str(dec)+'_'+str(radius)+'.csv'
         logging.warning("Filename for the output: %s" % outfile)

--- a/scripts/specsearch
+++ b/scripts/specsearch
@@ -144,7 +144,7 @@ def parseArguments(args,cp):
                 dcat = cp.get(cat)
                 if 'columns' in dcat:
                     cols = dcat.get('columns')
-                    cols = string.split(cols,',')
+                    cols = str.split(cols,',')
                 else:
                     cols = []
         else:
@@ -268,7 +268,7 @@ if __name__ == '__main__':
         sys.exit(EXIT_EMPTY)
 
     outfile = args.outfile
-    if args.outfile is '':
+    if args.outfile == '':
         logging.warning("An empty name for output filename was given.")
         outfile = str(ra)+'_'+str(dec)+'_'+str(radius)+'.csv'
         logging.warning("Filename for the output: %s" % outfile)

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(name=PACKAGE,
     packages=find_packages(),
     scripts=scripts,
     install_requires=[
-        'astropy==4.1', #required by new pyvo
+        'astropy', #required by new pyvo
         'pyvo==1.5', #for new catalogs
         'ipython==7.32.0', #'IPython.utils.io' has no attribute 'IOStream'
         'timeout_decorator',

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,9 @@ setup(name=PACKAGE,
     packages=find_packages(),
     scripts=scripts,
     install_requires=[
-        'astropy<4',
-        'pyvo==0.6.1',
+        'astropy==4.1', #required by new pyvo
+        'pyvo==1.5', #for new catalogs
+        'ipython==7.32.0', #'IPython.utils.io' has no attribute 'IOStream'
         'timeout_decorator',
         'pyyaml'
     ],


### PR DESCRIPTION
Dear eada developers,

I am using eada to perform catalogue conesearch, usually with the VOU-Blazars software.
As I have reported in #8 , some new catalogues are not compatible with the pyvo version which eada is currently built with.

I have found that this can be solved by setting in the setup the version pyvo==1.5, and since it requires at least astropy>4, it is also required to change the astropy version.

Other changes, related to the new pyvo, astropy and python versions:

- scsTab.votable.to_table() has been replaced with scsTab.votable.get_first_table().to_table(), since now astropy.votable presents a nested structure (https://docs.astropy.org/en/stable/io/votable/index.html);
- func__doc has been replaced with __doc__;
- split has been replaced with str.split;
- string equality condition "is" has been replaced with "==", according to Python warning;
- ConfigParser is called with interpolation=None to avoid crashes when reading urls with %2F symbols

Please let me know if these changes are reasonable, and if you have any question.

Best Regards,
Antonio Iuliano
